### PR TITLE
update images to include `/food/` prefix

### DIFF
--- a/_recipes/cuban-white-rice.md
+++ b/_recipes/cuban-white-rice.md
@@ -3,7 +3,7 @@
 
 # Cuban White Rice
 
-![Cuban White Rice](/images/cuban-white-rice.jpg)
+![Cuban White Rice](/food/images/cuban-white-rice.jpg)
 
 ## Ingredients
 Serves: 3-4 people

--- a/_recipes/kimchi-stew.md
+++ b/_recipes/kimchi-stew.md
@@ -3,7 +3,7 @@
 
 # Kimchi Jjigae (aka Kimchi Stew)
 
-![Kimchi Stew](../images/Kimchi-Stew.jpeg)
+![Kimchi Stew](/food/images/Kimchi-Stew.jpeg)
 
 ## Ingredients
 Serves: 2


### PR DESCRIPTION
Fixes the images - before they were served on root path `/` but since github pages uses `/${repo}` as the default prefix we need to update the path we use for images.